### PR TITLE
fix(howitworksbanner): make grid responsive

### DIFF
--- a/client/src/components/HowItWorks/HowItWorksBanner.component.tsx
+++ b/client/src/components/HowItWorks/HowItWorksBanner.component.tsx
@@ -18,7 +18,7 @@ const HowItWorksBanner = ({
     <SimpleGrid
       templateColumns={
         isMaxThreeInGrid
-          ? 'repeat(3,1fr)'
+          ? { base: '1fr', md: 'repeat(3,1fr)' }
           : {
               base: '1fr',
               md: 'repeat(3,1fr)',


### PR DESCRIPTION
How it works graphics shows up in a single column for mobile, and in a grid of three otherwise