### PR TITLE
refactor(api-client): migrate to shared types

### DIFF
--- a/client/src/api/types/addressee.ts
+++ b/client/src/api/types/addressee.ts
@@ -1,7 +1,0 @@
-import { Addressee } from '~shared/types/base'
-import { MessageResponse } from './common'
-
-export type CreateAddresseeReqDto = Pick<Addressee, 'name' | 'shortName'>
-
-// Returns signature ID
-export type CreateAddresseeResDto = MessageResponse & { data: number }

--- a/client/src/api/types/auth.ts
+++ b/client/src/api/types/auth.ts
@@ -1,3 +1,0 @@
-import { AuthUserDto } from '~shared/types/api'
-
-export type BaseUserNameDto = Pick<AuthUserDto, 'fullname'>

--- a/client/src/api/types/common.ts
+++ b/client/src/api/types/common.ts
@@ -1,4 +1,0 @@
-export type MessageResponse = {
-  message: string
-  data: unknown
-}

--- a/client/src/api/types/index.ts
+++ b/client/src/api/types/index.ts
@@ -1,4 +1,1 @@
 export * from './post'
-export * from './signature'
-export * from './addressee'
-export * from './auth'

--- a/client/src/api/types/post.ts
+++ b/client/src/api/types/post.ts
@@ -1,5 +1,5 @@
+import { MessageData } from '~shared/types/api'
 import { Addressee, Post, Signature } from '~shared/types/base'
-import { MessageResponse } from './common'
 
 // Backend does not select updatedAt
 export type GetSinglePostDto = Post & {
@@ -25,8 +25,8 @@ export type CreatePostReqDto = Pick<
   | 'email'
 >
 
-export type CreatePostResDto = MessageResponse & { data: number }
+export type CreatePostResDto = MessageData<number>
 
 export type UpdatePostReqDto = CreatePostReqDto
 
-export type UpdatePostResDto = MessageResponse
+export type UpdatePostResDto = MessageData

--- a/client/src/api/types/signature.ts
+++ b/client/src/api/types/signature.ts
@@ -1,9 +1,0 @@
-import { MessageResponse } from './common'
-
-export type CreateSignatureReqDto = {
-  comment: string | null
-  useName: boolean
-}
-
-// Returns signature ID
-export type CreateSignatureResDto = MessageResponse & { data: number }

--- a/client/src/components/SignForm/SignForm.component.tsx
+++ b/client/src/components/SignForm/SignForm.component.tsx
@@ -1,19 +1,20 @@
 import { Button, useDisclosure } from '@chakra-ui/react'
+import { useEffect } from 'react'
 import { SubmitHandler } from 'react-hook-form'
-import { CreateSignatureReqDto, GetSinglePostDto } from '../../api'
+import { BiLockAlt, BiPen } from 'react-icons/bi'
+import { useSearchParams } from 'react-router-dom'
+import { CreateSignatureReqDto } from '~shared/types/api'
+import { PostStatus } from '~shared/types/base'
+import { GetSinglePostDto } from '../../api'
+import { PreSignModal } from '../../components/PreSignModal/PreSignModal.component'
+import { useAuth } from '../../contexts/AuthContext'
 import * as SignatureService from '../../services/SignatureService'
 import { SignatureModal } from '../SignatureModal/SignatureModal.component'
-import {
-  SubscriptionModal,
-  SubscriptionFormValues,
-} from '../SubscriptionModal/SubscriptionModal.component'
-import { PreSignModal } from '../../components/PreSignModal/PreSignModal.component'
 import { useStyledToast } from '../StyledToast/StyledToast'
-import { PostStatus } from '~shared/types/base'
-import { useSearchParams } from 'react-router-dom'
-import { useEffect } from 'react'
-import { BiLockAlt, BiPen } from 'react-icons/bi'
-import { useAuth } from '../../contexts/AuthContext'
+import {
+  SubscriptionFormValues,
+  SubscriptionModal,
+} from '../SubscriptionModal/SubscriptionModal.component'
 
 type FormValues = CreateSignatureReqDto
 const refreshPage = async () => window.location.reload()

--- a/client/src/components/SignatureModal/SignatureModal.component.tsx
+++ b/client/src/components/SignatureModal/SignatureModal.component.tsx
@@ -13,18 +13,18 @@ import {
   ModalHeader,
   ModalOverlay,
   ModalProps,
+  Spinner,
   Switch,
   Text,
   Textarea,
   useMultiStyleConfig,
   VStack,
-  Spinner,
 } from '@chakra-ui/react'
-import { CreateSignatureReqDto } from '../../api'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
-import { Link as RouterLink } from 'react-router-dom'
 import { BiLinkExternal } from 'react-icons/bi'
+import { Link as RouterLink } from 'react-router-dom'
+import { CreateSignatureReqDto } from '~shared/types/api'
 import { useAuth } from '../../contexts/AuthContext'
 
 const MAX_CHAR_COUNT = 200

--- a/client/src/services/AddresseeService.ts
+++ b/client/src/services/AddresseeService.ts
@@ -1,17 +1,6 @@
-import { AxiosResponse } from 'axios'
-import { CreateSignatureReqDto } from 'src/api/types/signature'
 import { ApiClient } from '../api'
 
 export const getAddressees = async (): Promise<undefined> =>
   ApiClient.get<undefined>(`/addressees`).then(({ data }) => data)
 
 export const GET_ADDRESSEES_QUERY_KEY = 'getAddressees'
-
-export const createSignature = async (
-  postId: number,
-  data: CreateSignatureReqDto,
-): Promise<undefined> =>
-  ApiClient.post<undefined, AxiosResponse<undefined>>(
-    `/posts/signatures/${postId}`,
-    data,
-  ).then(({ data }) => data)

--- a/client/src/services/AuthService.ts
+++ b/client/src/services/AuthService.ts
@@ -1,7 +1,8 @@
-import { ApiClient, BaseUserNameDto } from '../api'
+import { LoadUserNameDto } from '~shared/types/api'
+import { ApiClient } from '../api'
 
-export const getUserName = async (): Promise<BaseUserNameDto> => {
-  return ApiClient.get<BaseUserNameDto>(`/auth/fullname`, {}).then(
+export const getUserName = async (): Promise<LoadUserNameDto> => {
+  return ApiClient.get<LoadUserNameDto>(`/auth/fullname`, {}).then(
     ({ data }) => data,
   )
 }

--- a/client/src/services/SignatureService.ts
+++ b/client/src/services/SignatureService.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from 'axios'
 import { Signature } from '~shared/types/base'
 import { ApiClient } from '../api'
-import { CreateSignatureReqDto } from '../api/types/signature'
+import { CreateSignatureReqDto } from '~shared/types/api'
 
 export const getUserSignatureForPost = async (
   postId: number,

--- a/server/src/modules/signatures/signature.controller.ts
+++ b/server/src/modules/signatures/signature.controller.ts
@@ -1,12 +1,13 @@
 import { validationResult } from 'express-validator'
-import { SignatureService } from './signature.service'
-import { createLogger } from '../../bootstrap/logging'
 import { StatusCodes } from 'http-status-codes'
-import { ControllerHandler } from '../../types/response-handler'
-import { Message } from '../../types/message-type'
+import { CreateSignatureReqDto } from '~shared/types/api'
 import { Signature } from '~shared/types/base'
-import { PostService } from '../post/post.service'
+import { createLogger } from '../../bootstrap/logging'
+import { Message } from '../../types/message-type'
+import { ControllerHandler } from '../../types/response-handler'
 import { hashData } from '../../util/hash'
+import { PostService } from '../post/post.service'
+import { SignatureService } from './signature.service'
 
 const logger = createLogger(module)
 
@@ -69,7 +70,7 @@ export class SignatureController {
   createSignature: ControllerHandler<
     { id: string },
     number | Message,
-    { useName: boolean; comment: string | null },
+    CreateSignatureReqDto,
     undefined
   > = async (req, res) => {
     const errors = validationResult(req)

--- a/shared/src/types/api/common.ts
+++ b/shared/src/types/api/common.ts
@@ -1,3 +1,8 @@
 export type ErrorDto = {
   message: string
 }
+
+export type MessageData<T = unknown> = {
+  message: string
+  data: T
+}

--- a/shared/src/types/api/index.ts
+++ b/shared/src/types/api/index.ts
@@ -1,3 +1,4 @@
 export * from './auth'
 export * from './common'
 export * from './env'
+export * from './signature'

--- a/shared/src/types/api/signature.ts
+++ b/shared/src/types/api/signature.ts
@@ -1,0 +1,9 @@
+import { MessageData } from './common'
+
+export type CreateSignatureReqDto = {
+  comment: string | null
+  useName: boolean
+}
+
+// Returns signature ID
+export type CreateSignatureResDto = MessageData<number>


### PR DESCRIPTION
## Problem and Solution

Continue to clean up the types used by the frontend's API client

- Remove addressee types, not used
- Remove auth types and use LoadUserNameDto in AuthService
- Move signature types to shared, use in backend
- Remove `AddresseeService.createSignature()`, not used
- Refactor `MessageResponse` to `MessageData<T>`, and rework all
  references to take advantage of generic type param for conciseness

