### PR TITLE
refactor(imports): use relative imports instead of absolute import

### DIFF
--- a/server/src/modules/auth/__tests__/auth.middleware.spec.ts
+++ b/server/src/modules/auth/__tests__/auth.middleware.spec.ts
@@ -1,9 +1,9 @@
-import supertest from 'supertest'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { ControllerHandler } from '../../../types/response-handler'
 import { mockUserJWT } from '../../../util/db/data/user'
 import { AuthMiddleware } from '../auth.middleware'
-import { ControllerHandler } from 'src/types/response-handler'
 
 describe('auth.middleware', () => {
   // Set up auth middleware to inject user

--- a/server/src/modules/auth/__tests__/auth.routes.spec.ts
+++ b/server/src/modules/auth/__tests__/auth.routes.spec.ts
@@ -1,24 +1,24 @@
-import supertest from 'supertest'
+import SgidClient from '@opengovsg/sgid-client'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import {
-  createTestDatabase,
-  resetAndSetupDb,
-  SequelizeWithModels,
-} from '../../../util/db/jest-db'
+import supertest from 'supertest'
+import { PostService } from '../../../modules/post/post.service'
+import { ControllerHandler } from '../../../types/response-handler'
+import { POST_ID } from '../../../util/db/constants'
 import {
   mockOtherUserJWT,
   mockUser,
   mockUserJWT,
 } from '../../../util/db/data/user'
-import { POST_ID } from '../../../util/db/constants'
-import { routeAuth } from '../auth.routes'
+import {
+  createTestDatabase,
+  resetAndSetupDb,
+  SequelizeWithModels,
+} from '../../../util/db/jest-db'
 import { AuthController } from '../auth.controller'
-import { PostService } from '../../../modules/post/post.service'
-import { AuthService } from '../auth.service'
 import { AuthMiddleware } from '../auth.middleware'
-import SgidClient from '@opengovsg/sgid-client'
-import { ControllerHandler } from 'src/types/response-handler'
+import { routeAuth } from '../auth.routes'
+import { AuthService } from '../auth.service'
 
 describe('/auth', () => {
   let db: SequelizeWithModels

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -1,19 +1,19 @@
+import SgidClient from '@opengovsg/sgid-client'
 import { StatusCodes } from 'http-status-codes'
-import { formCallbackRedirectURL } from '../../bootstrap/config/auth'
-import { Message } from 'src/types/message-type'
 import {
   ErrorDto,
   LoadPublicUserDto,
   LoadUserNameDto,
   UserAuthType,
 } from '~shared/types/api'
+import { formCallbackRedirectURL } from '../../bootstrap/config/auth'
 import { createLogger } from '../../bootstrap/logging'
+import { Message } from '../../types/message-type'
 import { ControllerHandler } from '../../types/response-handler'
-import { AuthService } from '../auth/auth.service'
-import { PostService } from '../post/post.service'
 import { hashData } from '../../util/hash'
 import { decodeUserJWT, encodeUserJWT } from '../../util/jwt'
-import SgidClient from '@opengovsg/sgid-client'
+import { AuthService } from '../auth/auth.service'
+import { PostService } from '../post/post.service'
 
 const logger = createLogger(module)
 export class AuthController {


### PR DESCRIPTION
Some minor housekeeping: use relative imports instead of absolute imports.