### PR TITLE
fix(build): add build to import paths

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,       /* Disallow inconsistently-cased references to the same file. */
     "paths": {
       "~shared/*": ["../shared/build/*"],
-      "@/*": ["src/*"]
+      "@/*": ["src/*", "build/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Problem

There was a build error in production as the compiler cannot resolve path to `build` folder.

## Solution

Add `build/*` to paths for `@/*`

