### PR TITLE
fix(auth): clear user data after signing petition

### DIFF
--- a/client/src/components/InfoBox/InfoBox.component.tsx
+++ b/client/src/components/InfoBox/InfoBox.component.tsx
@@ -1,18 +1,20 @@
 import { Box, HStack } from '@chakra-ui/layout'
 import { Icon, useMultiStyleConfig } from '@chakra-ui/react'
-import { BiInfoCircle } from 'react-icons/bi'
+import { BiErrorCircle, BiInfoCircle } from 'react-icons/bi'
 
 export const InfoBox = ({
   children,
+  variant,
 }: {
   children: JSX.Element
+  variant?: string
 }): JSX.Element | null => {
-  const styles = useMultiStyleConfig('InfoBox', {})
+  const styles = useMultiStyleConfig('InfoBox', { variant })
   return (
     <Box sx={styles.infoBox}>
       <HStack sx={styles.infoStack}>
         <Icon
-          as={BiInfoCircle}
+          as={variant === 'danger' ? BiErrorCircle : BiInfoCircle}
           color="primary.500"
           w="20px"
           h="20px"

--- a/client/src/components/PostSignatures/PostSignature.component.tsx
+++ b/client/src/components/PostSignatures/PostSignature.component.tsx
@@ -5,7 +5,7 @@ import { Signature } from '~shared/types/base'
 export const PostSignature = ({
   signature,
 }: {
-  signature: Pick<Signature, 'comment' | 'createdAt' | 'fullname'>
+  signature: Pick<Signature, 'comment' | 'createdAt' | 'fullname' | 'id'>
 }): JSX.Element => {
   return (
     <Box my="16px">

--- a/client/src/components/PostSignatures/PostSignatures.component.tsx
+++ b/client/src/components/PostSignatures/PostSignatures.component.tsx
@@ -12,7 +12,9 @@ export const PostSignatures = ({
   const showAllComments = signatures
     .reverse()
     .slice(0, 10)
-    .map((signature) => <PostSignature signature={signature} />)
+    .map((signature) => (
+      <PostSignature signature={signature} key={signature.id} />
+    ))
 
   return (
     <>

--- a/client/src/components/PreSignModal/PreSignModal.component.tsx
+++ b/client/src/components/PreSignModal/PreSignModal.component.tsx
@@ -19,6 +19,9 @@ import { useEffect, useState } from 'react'
 import { PostWithAddresseeAndSignatures } from '~shared/types/api'
 import { PostStatus } from '~shared/types/base'
 import { SGID_REDIRECT_URI } from '@/api/Sgid'
+import { InfoBox } from '../InfoBox/InfoBox.component'
+import { BiLinkExternal } from 'react-icons/bi'
+import { Link as RouterLink } from 'react-router-dom'
 
 type PreSignModalProps = Pick<ModalProps, 'isOpen' | 'onClose'> & {
   isEndorser: boolean
@@ -35,15 +38,24 @@ export const PreSignModal = ({
   post,
 }: PreSignModalProps): JSX.Element => {
   const [useName, setUseName] = useState(false)
-
+  const [activeStep, setActiveStep] = useState(0)
   const styles = useMultiStyleConfig('PreSignModal', {})
-
   const onClickSgid = async (redirect: string) => {
     window.location.href = `${SGID_REDIRECT_URI}?redirect=${redirect}&useName=${useName}`
   }
+  const onCloseAndReset = () => {
+    onClose()
+    setActiveStep(0)
+  }
+
+  useEffect(() => {
+    if (post?.status === PostStatus.Draft) {
+      setUseName(true)
+    }
+  })
 
   const useNameComponent = (
-    <Flex>
+    <Flex sx={styles.disclaimerContainer}>
       <VStack sx={styles.disclaimerBox}>
         <Box>
           <Text sx={styles.disclaimerHeader}>
@@ -66,59 +78,150 @@ export const PreSignModal = ({
     </Flex>
   )
 
-  useEffect(() => {
-    if (post?.status === PostStatus.Draft) {
-      setUseName(true)
+  const preEndorseContent = (
+    <Box>
+      <Text sx={styles.text}>
+        You have been requested by {petitionOwner} to be an endorser of this
+        petition. You will be using your Singpass login and having your full
+        name published on the petition page as an endorser.
+      </Text>
+      <Text sx={styles.text}>
+        Please read through the petition carefully before endorsing it.
+      </Text>
+    </Box>
+  )
+
+  const preSignStepOne = (
+    <InfoBox variant="info">
+      <Text>
+        You will be using your Singpass login sign this petition. Please read
+        through the petition carefully before proceeding.
+        <br />
+        <br />
+        Choosing to sign with your name will only retrieve your Singpass name.
+        Other details like your address and NRIC are never retrieved from
+        Singpass, so can never be leaked from PetitionsSG.
+      </Text>
+    </InfoBox>
+  )
+
+  const preSignStepTwo = (
+    <>
+      <InfoBox variant="info">
+        <>
+          <Text>
+            PetitionsSG offers the option to sign a petition anonymously,
+            because we understand public civic participation in Singapore on
+            certain topics could come with some social stigma attached.
+          </Text>
+          <RouterLink to="/anonymity">
+            <Flex alignItems="center" mt="20px">
+              <Text
+                _hover={{
+                  color: 'primary.600',
+                }}
+                sx={styles.anonymityButton}
+                as="u"
+              >
+                Read more about how we ensure anonymity
+              </Text>
+              <Box color="primary.500">
+                <BiLinkExternal />
+              </Box>
+            </Flex>
+          </RouterLink>
+        </>
+      </InfoBox>
+      {post?.status === PostStatus.Open && useNameComponent}
+    </>
+  )
+
+  const sgidButton = (
+    <Button
+      sx={styles.proceedButton}
+      onClick={() => onClickSgid(`${location.pathname}?sign`)}
+      _hover={{
+        bg: 'secondary.600',
+      }}
+    >
+      Proceed
+    </Button>
+  )
+
+  const nextButton = (
+    <Button
+      sx={styles.proceedButton}
+      onClick={() => setActiveStep(1)}
+      _hover={{
+        bg: 'secondary.600',
+      }}
+    >
+      Proceed
+    </Button>
+  )
+
+  const backButton = (
+    <Button
+      sx={styles.cancelButton}
+      _hover={{
+        bg: 'secondary.100',
+      }}
+      onClick={() => setActiveStep(0)}
+    >
+      Back
+    </Button>
+  )
+
+  const cancelButton = (
+    <Button sx={styles.cancelButton} onClick={onClose}>
+      Cancel
+    </Button>
+  )
+
+  const getPreSignStepContent = (step: number) => {
+    switch (step) {
+      case 1:
+        return preSignStepTwo
+      case 0:
+      default:
+        return preSignStepOne
     }
-  })
+  }
+
+  const getNextStepButton = (step: number) => {
+    switch (step) {
+      case 1:
+        return sgidButton
+      case 0:
+      default:
+        return nextButton
+    }
+  }
+
+  const getCancelStepButton = (step: number) => {
+    switch (step) {
+      case 1:
+        return backButton
+      case 0:
+      default:
+        return cancelButton
+    }
+  }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <Modal isOpen={isOpen} onClose={onCloseAndReset} size="xl">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader textStyle={'h2'}>
-          You're signing this petition with your Singpass
+          You will be signing this petition with your Singpass
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          {isEndorser ? (
-            <Box>
-              <Text sx={styles.text}>
-                You have been requested by {petitionOwner} to be an endorser of
-                this petition. You will be using your Singpass login and having
-                your full name published on the petition page as an endorser.
-              </Text>
-              <Text sx={styles.text}>
-                Please read through the petition carefully before endorsing it.
-              </Text>
-            </Box>
-          ) : (
-            <Text sx={styles.text}>
-              You will be using your Singpass login to sign this petition.
-              Please read through the petition carefully before signing it.
-            </Text>
-          )}
-          {post?.status === PostStatus.Open && useNameComponent}
+          {isEndorser ? preEndorseContent : getPreSignStepContent(activeStep)}
         </ModalBody>
         <ModalFooter>
-          <Button
-            onClick={onClose}
-            sx={styles.cancelButton}
-            _hover={{
-              bg: 'secondary.100',
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            sx={styles.proceedButton}
-            onClick={() => onClickSgid(`${location.pathname}?sign`)}
-            _hover={{
-              bg: 'secondary.600',
-            }}
-          >
-            Proceed and sign
-          </Button>
+          {isEndorser ? cancelButton : getCancelStepButton(activeStep)}
+          {isEndorser ? sgidButton : getNextStepButton(activeStep)}
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/client/src/components/SignForm/SignForm.component.tsx
+++ b/client/src/components/SignForm/SignForm.component.tsx
@@ -19,7 +19,6 @@ import {
 } from '../SubscriptionModal/SubscriptionModal.component'
 
 type FormValues = CreateSignatureReqDto
-const refreshPage = async () => window.location.reload()
 
 const SignForm = ({
   post,
@@ -29,9 +28,29 @@ const SignForm = ({
   postId: string | undefined
 }): JSX.Element => {
   const toast = useStyledToast()
-  const { user } = useAuth()
+  const { user, logout } = useAuth()
   const [searchParams] = useSearchParams()
   const openSignatureModal = searchParams.has('sign')
+
+  const refreshPage = async () => {
+    window.location.reload()
+  }
+
+  // Event listener to clear user data when navigating away from the page
+  useEffect(() => {
+    window.addEventListener('beforeunload', logout)
+    return () => window.removeEventListener('beforeunload', logout)
+  }, [])
+
+  // Event listener to refresh page when page is loaded using back/forward navigation
+  useEffect(() => {
+    if (
+      window.performance?.getEntriesByType('navigation')[0].type ===
+      'back_forward'
+    ) {
+      refreshPage()
+    }
+  }, [])
 
   // Init PreSignModal
   const {
@@ -81,6 +100,11 @@ const SignForm = ({
     refreshPage()
   }
 
+  const onSignatureModalCloseAndLogout = () => {
+    onSignatureModalClose()
+    logout()
+  }
+
   useEffect(() => {
     if (openSignatureModal && user) {
       onSignatureModalOpen()
@@ -114,7 +138,7 @@ const SignForm = ({
       />
       <SignatureModal
         isOpen={isSignatureModalOpen}
-        onClose={onSignatureModalClose}
+        onClose={onSignatureModalCloseAndLogout}
         onConfirm={onSignatureConfirm}
         postTitle={post?.title ?? ''}
         useFullname={post?.status === PostStatus.Draft}

--- a/client/src/components/SignatureModal/SignatureModal.component.tsx
+++ b/client/src/components/SignatureModal/SignatureModal.component.tsx
@@ -22,8 +22,6 @@ import {
 } from '@chakra-ui/react'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
-import { BiLinkExternal } from 'react-icons/bi'
-import { Link as RouterLink } from 'react-router-dom'
 import { CreateSignatureReqDto } from '~shared/types/api'
 import { useAuth } from '@/contexts/AuthContext'
 
@@ -45,13 +43,14 @@ export const SignatureModal = ({
   const [count, setCount] = useState(MAX_CHAR_COUNT)
   const styles = useMultiStyleConfig('SignatureModal', {})
   const { register, handleSubmit, reset } = useForm<FormValues>()
-  const [showDisclaimer, toggleShowDisclaimer] = useState(false)
+  const [showDisclaimer, toggleShowDisclaimer] = useState(true)
   const onSubmit: SubmitHandler<CreateSignatureReqDto> = async ({
     comment,
     useName,
   }) => {
     await onConfirm({ comment: comment, useName: useName || useFullname })
     reset()
+    onClose()
   }
 
   const { user, isLoading: isUserLoading } = useAuth()
@@ -102,6 +101,7 @@ export const SignatureModal = ({
       {user?.fullname && (
         <Flex ms="auto">
           <Switch
+            defaultChecked={true}
             alignSelf="flex-end"
             colorScheme="green"
             {...register('useName', {})}
@@ -147,24 +147,6 @@ export const SignatureModal = ({
             </Flex>
             {signatureComponent}
             {useFullname ? endorserNameComponent : useNameComponent}
-            {!useFullname && (
-              <RouterLink to="/anonymity">
-                <Flex alignItems="center" mt="20px">
-                  <Text
-                    _hover={{
-                      color: 'primary.600',
-                    }}
-                    sx={styles.anonymityButton}
-                    as="u"
-                  >
-                    Read more about how we ensure anonymity
-                  </Text>
-                  <Box color="primary.500">
-                    <BiLinkExternal />
-                  </Box>
-                </Flex>
-              </RouterLink>
-            )}
           </ModalBody>
           <ModalFooter>
             <Button
@@ -178,7 +160,7 @@ export const SignatureModal = ({
             </Button>
             <Button
               type="submit"
-              onClick={onClose}
+              onClick={() => onSubmit}
               _hover={{
                 bg: 'secondary.600',
               }}

--- a/client/src/components/SignedModal/SignedModal.component.tsx
+++ b/client/src/components/SignedModal/SignedModal.component.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalProps,
+  Text,
+} from '@chakra-ui/react'
+import { InfoBox } from '../InfoBox/InfoBox.component'
+
+type SignedModalProps = Pick<ModalProps, 'isOpen' | 'onClose'>
+
+export const SignedModal = ({
+  isOpen,
+  onClose,
+}: SignedModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader fontSize="24px" pt="4">
+          You have already signed this petition
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <InfoBox variant="danger">
+            <Text>
+              You can only sign a petition once. You’ve previously used your
+              Singpass login to sign this petition.
+            </Text>
+          </InfoBox>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            type="submit"
+            bg="secondary.500"
+            fontStyle={'subhead-1'}
+            color="white"
+            onClick={onClose}
+            _hover={{
+              bg: 'secondary.600',
+            }}
+          >
+            Back to petition
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/client/src/components/Spinner/Spinner.component.tsx
+++ b/client/src/components/Spinner/Spinner.component.tsx
@@ -5,13 +5,13 @@ import {
 } from '@chakra-ui/react'
 
 interface SpinnerProps extends ChakraSpinnerProps {
-  centerWidth?: string | number
-  centerHeight?: string | number
+  centerwidth?: string | number
+  centerheight?: string | number
 }
 
 const Spinner = (props: SpinnerProps): JSX.Element => {
   return (
-    <Center w={props.centerWidth} h={props.centerHeight}>
+    <Center w={props.centerwidth} h={props.centerheight}>
       <ChakraSpinner {...props} />
     </Center>
   )

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,12 +1,14 @@
 import { AxiosError } from 'axios'
 import { createContext, useContext, useEffect, useState } from 'react'
-import { ApiClient } from '@/api'
+import { ApiClient, getApiErrorMessage } from '@/api'
 import { LoadPublicUserDto } from '~shared/types/api'
 import { useLocation } from 'react-router-dom'
+import { useStyledToast } from '@/components/StyledToast/StyledToast'
 
 interface AuthContextProps {
   user: LoadPublicUserDto
   isLoading: boolean
+  logout: () => void
 }
 
 const authContext = createContext<AuthContextProps | undefined>(undefined)
@@ -24,6 +26,7 @@ export const AuthProvider = ({
 }): JSX.Element => {
   const [isLoading, setLoading] = useState<boolean>(true)
   const [user, setUser] = useState<LoadPublicUserDto>(null)
+  const toast = useStyledToast()
   const { pathname } = useLocation()
 
   const whoami = () => {
@@ -46,9 +49,25 @@ export const AuthProvider = ({
       })
   }
 
+  const logout = () => {
+    if (user) {
+      ApiClient.post('/auth/logout')
+        .then(() => {
+          setUser(null)
+        })
+        .catch((error) => {
+          toast({
+            status: 'error',
+            description: getApiErrorMessage(error),
+          })
+        })
+    }
+  }
+
   const auth = {
     user,
     isLoading,
+    logout,
   }
 
   const initialize = () => {

--- a/client/src/pages/Post/Post.component.tsx
+++ b/client/src/pages/Post/Post.component.tsx
@@ -130,6 +130,8 @@ const Post = (): JSX.Element => {
     isUserLoading ||
     isPetitionOwnerLoading
 
+  const showSignForm = !(PostStatus.Draft && isPetitionOwner)
+
   return isLoading ? (
     <Spinner centerheight={`${styles.spinner.height}`} />
   ) : (
@@ -197,11 +199,7 @@ const Post = (): JSX.Element => {
                 have signed this petition
               </Text>
             </Box>
-            {((post?.status === PostStatus.Draft &&
-              !userSignature &&
-              !isPetitionOwner) ||
-              (post?.status === PostStatus.Open && !userSignature) ||
-              !user) && <SignForm post={post} postId={postId} />}
+            {showSignForm && <SignForm post={post} postId={postId} />}
 
             {post?.status === PostStatus.Draft && isPetitionOwner && (
               <Button
@@ -214,9 +212,6 @@ const Post = (): JSX.Element => {
               >
                 Share private link
               </Button>
-            )}
-            {user && userSignature && (
-              <Center sx={styles.signed}>You have signed this petition.</Center>
             )}
             {(user && !userSignature) ||
               (!user && (

--- a/client/src/pages/Post/Post.component.tsx
+++ b/client/src/pages/Post/Post.component.tsx
@@ -110,7 +110,7 @@ const Post = (): JSX.Element => {
           .reverse()
           .slice(0, 10)
           .map((signature) => (
-            <Box>
+            <Box key={signature.id}>
               <Text sx={styles.signature}>
                 {signature.fullname ?? 'Anonymous'} signed this petition
               </Text>
@@ -131,7 +131,7 @@ const Post = (): JSX.Element => {
     isPetitionOwnerLoading
 
   return isLoading ? (
-    <Spinner centerHeight={`${styles.spinner.height}`} />
+    <Spinner centerheight={`${styles.spinner.height}`} />
   ) : (
     <Flex direction="column" sx={styles.container}>
       {post?.status === PostStatus.Draft && (

--- a/client/src/services/SignatureService.ts
+++ b/client/src/services/SignatureService.ts
@@ -21,7 +21,7 @@ export const createSignature = async (
   ).then(({ data }) => data)
 
 export const filterSignaturesWithComments = (
-  signatures: Pick<Signature, 'comment' | 'createdAt' | 'fullname'>[],
+  signatures: Pick<Signature, 'comment' | 'createdAt' | 'fullname' | 'id'>[],
 ) => {
   return signatures.filter((signature) => signature.comment !== '')
 }

--- a/client/src/theme/components/InfoBox.ts
+++ b/client/src/theme/components/InfoBox.ts
@@ -18,4 +18,24 @@ export const InfoBox: ComponentMultiStyleConfig = {
       alignItems: 'flex-start',
     },
   }),
+  variants: {
+    danger: {
+      infoBox: {
+        bg: 'danger.100',
+      },
+    },
+    info: {
+      infoBox: {
+        bg: 'primary.100',
+      },
+    },
+    default: {
+      infoBox: {
+        bg: 'none',
+      },
+    },
+  },
+  defaultProps: {
+    variant: 'solid',
+  },
 }

--- a/client/src/theme/components/PreSignModal.ts
+++ b/client/src/theme/components/PreSignModal.ts
@@ -27,4 +27,11 @@ export const PreSignModal = makeMultiStyleConfig({
     fontWeight: '400',
     color: 'secondary.400',
   },
+  disclaimerContainer: {
+    mt: '24px',
+  },
+  anonymityButton: {
+    color: 'primary.500',
+    mr: '8px',
+  },
 })

--- a/client/src/theme/components/SignatureModal.ts
+++ b/client/src/theme/components/SignatureModal.ts
@@ -42,10 +42,6 @@ const styles = {
     textStyle: 'body-2',
     color: 'neutral.700',
   },
-  anonymityButton: {
-    color: 'primary.500',
-    mr: '8px',
-  },
   cancelButton: {
     bg: 'transparent',
     mx: '8px',

--- a/client/src/types/lib.dom.d.ts
+++ b/client/src/types/lib.dom.d.ts
@@ -1,0 +1,3 @@
+interface PerformanceEntry {
+  type: string
+}

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -61,6 +61,24 @@ export class AuthController {
     }
   }
 
+  /**
+   * Logout
+   * @returns 200 if logged out
+   */
+  handleLogout: ControllerHandler = (req, res) => {
+    if (!req.cookies.jwt) {
+      logger.error({
+        message: 'Attempted to sign out without a token',
+        meta: {
+          function: 'handleLogout',
+        },
+      })
+      return res.sendStatus(StatusCodes.BAD_REQUEST)
+    }
+    res.clearCookie('jwt')
+    return res.status(StatusCodes.OK).json({ message: 'Sign out successful' })
+  }
+
   handleSgidLogin: ControllerHandler<
     never,
     undefined,

--- a/server/src/modules/auth/auth.routes.ts
+++ b/server/src/modules/auth/auth.routes.ts
@@ -45,6 +45,14 @@ export const routeAuth = ({
   router.get('/sgid/login', limiter, controller.handleSgidLogin)
 
   /**
+   * Logout
+   * @route   POST /api/auth/logout
+   * @returns 200 on successful logout
+   * @access  private
+   */
+  router.post('/logout', controller.handleLogout)
+
+  /**
    * Sgid Callback
    * @route   GET /api/auth/callback
    * @returns 302 to home page if successful login


### PR DESCRIPTION
## Problem

Previously, users are able to still sign a petition when they refresh the page or click on the browser back button after navigating away. 

Closes [#295]


## Solution

On closing the signature modal or navigating to another page, user data will be cleared.

The screen recording shows two scenarios:
1. On user refresh
2. On user navigate away

https://user-images.githubusercontent.com/41635847/154938995-24f0d8c8-d131-4123-9224-16dfc370b758.mov

**Update 1 Mar: Added new flow and designs for pre-signing**

https://user-images.githubusercontent.com/41635847/156139919-ead22497-d27f-4881-a121-c02221eef287.mov


