### PR TITLE
fix(subscription): user should not sign out before subscribing

### DIFF
--- a/client/src/components/SignForm/SignForm.component.tsx
+++ b/client/src/components/SignForm/SignForm.component.tsx
@@ -117,6 +117,11 @@ const SignForm = ({
     logout()
   }
 
+  const onSubscriptionModalCloseAndLogout = () => {
+    onSubscriptionModalClose()
+    logout()
+  }
+
   // Init Signed Modal
   const {
     onOpen: onSignedModalOpen,
@@ -160,11 +165,12 @@ const SignForm = ({
 
       <SubscriptionModal
         isOpen={isSubscriptionModalOpen}
-        onClose={onSubscriptionModalClose}
+        onClose={onSubscriptionModalCloseAndLogout}
         onConfirm={onSubscriptionConfirm}
       />
       <SignatureModal
         isOpen={isSignatureModalOpen}
+        onNext={onSignatureModalClose}
         onClose={onSignatureModalCloseAndLogout}
         onConfirm={onSignatureConfirm}
         postTitle={post?.title ?? ''}

--- a/client/src/components/SignatureModal/SignatureModal.component.tsx
+++ b/client/src/components/SignatureModal/SignatureModal.component.tsx
@@ -28,6 +28,7 @@ import { useAuth } from '@/contexts/AuthContext'
 const MAX_CHAR_COUNT = 200
 type FormValues = CreateSignatureReqDto
 interface SignatureModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
+  onNext: () => void
   onConfirm: (signatureReq: CreateSignatureReqDto) => Promise<void>
   postTitle: string
   useFullname: boolean
@@ -36,6 +37,7 @@ interface SignatureModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
 export const SignatureModal = ({
   isOpen,
   onClose,
+  onNext,
   onConfirm,
   postTitle,
   useFullname,
@@ -50,7 +52,8 @@ export const SignatureModal = ({
   }) => {
     await onConfirm({ comment: comment, useName: useName || useFullname })
     reset()
-    onClose()
+    // Closes modal without logging out, so that user continues to subscription.
+    onNext()
   }
 
   const { user, isLoading: isUserLoading } = useAuth()

--- a/client/src/components/SubscriptionModal/SubscriptionModal.component.tsx
+++ b/client/src/components/SubscriptionModal/SubscriptionModal.component.tsx
@@ -36,14 +36,19 @@ export const SubscriptionModal = ({
   onConfirm,
 }: SubscriptionModalProps): JSX.Element => {
   const { register, handleSubmit, reset } = useForm<FormValues>()
+  const closeModalAndRefreshPage = () => {
+    onClose()
+    refreshPage()
+  }
   const onSubmit: SubmitHandler<FormValues> = async ({ email }) => {
     if (email) {
       await onConfirm({ email: email })
       reset()
-      setTimeout(() => refreshPage(), 3000)
+      setTimeout(() => {
+        closeModalAndRefreshPage()
+      }, 3000)
     } else {
-      onClose()
-      refreshPage()
+      closeModalAndRefreshPage()
     }
   }
   const [copied, setCopied] = useState(false)


### PR DESCRIPTION
## Problem

The current signing flow goes like this:

PreSignModal -> SGID process ->SignatureModal -> SubscriptionModal

In #323, we clear user data after SignatureModal closes, but the subscription modal requires user data to successfully subscribe in #359. 

## Solution

To clear user data only when:
- The user closes the signature modal by clicking on the exit button
- The user closes the subscription modal (either by clicking `done` or the exit button)

User data should not be cleared when clicking `Confirm, sign petition`.