### PR TITLE
refactor: override proxy behaviour, generalise client redirect uri

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -61,6 +61,7 @@
         "@types/styled-components": "^5.1.24",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "http-proxy-middleware": "^2.0.3",
         "lint-staged": "12.3",
         "msw": "^0.39.0",
         "msw-storybook-addon": "^1.6.1",
@@ -20892,10 +20893,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.1",
-      "license": "MIT",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.3.tgz",
+      "integrity": "sha512-1bloEwnrHMnCoO/Gcwbz7eSVvW50KPES01PecpagI+YLNLci4AcuKJrujW4Mc3sBLpFxMSlsLNHS5Nl/lvrTPA==",
       "dependencies": {
-        "@types/http-proxy": "^1.17.5",
+        "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
@@ -20903,6 +20905,14 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
       }
     },
     "node_modules/https-browserify": {
@@ -48905,9 +48915,11 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.1",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.3.tgz",
+      "integrity": "sha512-1bloEwnrHMnCoO/Gcwbz7eSVvW50KPES01PecpagI+YLNLci4AcuKJrujW4Mc3sBLpFxMSlsLNHS5Nl/lvrTPA==",
       "requires": {
-        "@types/http-proxy": "^1.17.5",
+        "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -80,6 +80,7 @@
     "@types/styled-components": "^5.1.24",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "http-proxy-middleware": "^2.0.3",
     "lint-staged": "12.3",
     "msw": "^0.39.0",
     "msw-storybook-addon": "^1.6.1",

--- a/client/src/api/Sgid.ts
+++ b/client/src/api/Sgid.ts
@@ -1,4 +1,1 @@
-export const SGID_REDIRECT_URI =
-  process.env.NODE_ENV === 'production'
-    ? `${process.env.PUBLIC_URL}/api/v1/auth/sgid/login`
-    : 'http://localhost:6174/api/v1/auth/sgid/login'
+export const SGID_REDIRECT_URI = '/api/v1/auth/sgid/login'

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,0 +1,26 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createProxyMiddleware } = require('http-proxy-middleware')
+
+/**
+ * Forces all requests to `/api/v1/auth` to be proxied to the backend.
+ *
+ * This overrides default react-scripts behaviour for webpack-dev-server,
+ * which attempts to handle traffic where the Accept header contains `text/html`
+ * in its value.
+ *
+ * This may occur in typical OIDC authorization flow, when the browser
+ * changes its window.location.href to the service provider path to start
+ * the flow. When this happens, the browser would use a catch-all Accept header,
+ * and run into the react-scripts behaviour above, unless overridden.
+ *
+ * @param {Express} app Express app supplied by react-scripts for webpack-dev-server
+ */
+module.exports = function (app) {
+  app.use(
+    '/api/v1/auth',
+    createProxyMiddleware({
+      target: `http://localhost:${process.env.SERVER_PORT}`,
+      changeOrigin: true,
+    }),
+  )
+}


### PR DESCRIPTION
## Problem
The client should not be made aware of its environment as much as
possible. However, when starting the OIDC flow to log the user in,
the client has to manipulate window.location.href. This emits a request
using an http Accept header that induces react-scripts to
handle the request, rather than proxy it to the backend as desired[^1].

## Solution
To resolve this, override the default proxy behaviour by using
`src/setupProxy.js`, proxying _all_ requests to `/api/v1/auth` to the
backend.

- `npm install http-proxy-middleware`
- Provide a `src/setupProxy.js` which overrides default proxy behaviour
  so that we dutifully route auth requests to intended destination
- Remove references to `NODE_ENV` in `client/src/api/Sgid`

Blocked by #375 
Fixes #248 

[^1]: https://create-react-app.dev/docs/proxying-api-requests-in-development/
