### PR TITLE
refactor(envbanner): enable link rendering in the env banner

### DIFF
--- a/client/src/components/EnvBanner/EnvBanner.component.tsx
+++ b/client/src/components/EnvBanner/EnvBanner.component.tsx
@@ -1,5 +1,6 @@
 import { Box, HStack, Icon } from '@chakra-ui/react'
 import { BiInfoCircle } from 'react-icons/bi'
+import sanitizeHtml from 'sanitize-html'
 
 type bannerDataType =
   | {
@@ -26,9 +27,14 @@ export const EnvBanner = ({
       className="banner"
     >
       <HStack justifyContent="space-between" flexWrap="wrap">
-        <HStack alignItems="flex-start" mx="8" my="2">
+        <HStack alignItems="flex-start" mx="8" my="4">
           <Icon as={BiInfoCircle} />
-          <Box dangerouslySetInnerHTML={{ __html: data.bannerMessage }} />
+          <Box
+            dangerouslySetInnerHTML={{
+              __html: sanitizeHtml(data.bannerMessage),
+            }}
+          />
+          <Box></Box>
         </HStack>
       </HStack>
     </Box>

--- a/client/src/components/EnvBanner/EnvBanner.component.tsx
+++ b/client/src/components/EnvBanner/EnvBanner.component.tsx
@@ -1,4 +1,5 @@
-import { Box } from '@chakra-ui/layout'
+import { Box, HStack, Icon } from '@chakra-ui/react'
+import { BiInfoCircle } from 'react-icons/bi'
 
 type bannerDataType =
   | {
@@ -15,17 +16,21 @@ export const EnvBanner = ({
 }): JSX.Element | null => {
   return isSuccess && data?.bannerMessage ? (
     <Box
-      h="50px"
       minH="50px"
       color="neutral.100"
       zIndex="2000"
-      background="neutral.900"
+      background="primary.500"
       display="flex"
       justifyContent="center"
       alignItems="center"
       className="banner"
     >
-      {data.bannerMessage}
+      <HStack justifyContent="space-between" flexWrap="wrap">
+        <HStack alignItems="flex-start" mx="8" my="2">
+          <Icon as={BiInfoCircle} />
+          <Box dangerouslySetInnerHTML={{ __html: data.bannerMessage }} />
+        </HStack>
+      </HStack>
     </Box>
   ) : null
 }


### PR DESCRIPTION
## Problem

The previous env banner is unable to render urls.

## Solution

- Use `dangerouslySetInnerHTML` together with `sanitizeHtml` to allow the tags to properly render. 
- Update the design of banner according to latest figma design.

## Test
Can test with the following env variable
```
BANNER_MESSAGE='You’ve reached the prototype website of PetitionsSG, which was created as part of Open Government Products’ annual <u><a href="https://www.open.gov.sg/hackathon/2022/petitionssg">Hack for Public Good</a></u> hackathon. As this is a prototype project, petitioners should not expect to receive a ministry response. If you would like to participate in future user interviews for this platform, please sign up at <u><a href="https://go.gov.sg/petitions-survey">go.gov.sg/petitions-survey</a></u>.'
```

## Screenshots
<img width="1365" alt="Screenshot 2022-03-14 at 11 30 44 AM" src="https://user-images.githubusercontent.com/41635847/158100094-cc2d9ad2-d0e4-4e83-8e8c-d1dfaa02fc3c.png">
